### PR TITLE
refactor: pathlib.Path の参照を from pathlib import Path スタイルに統一

### DIFF
--- a/src/python_etl/etl.py
+++ b/src/python_etl/etl.py
@@ -9,7 +9,7 @@ Python + Pandas ETL サンプルプロジェクト
 
 import argparse
 import logging
-import pathlib
+from pathlib import Path
 from typing import Final
 
 from python_etl.extract import extract
@@ -33,13 +33,13 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Python + Pandas ETL パイプライン")
     parser.add_argument(
         "--input-dir",
-        type=pathlib.Path,
+        type=Path,
         default=None,
         help="入力CSVファイルのディレクトリ (デフォルト: data/raw)",
     )
     parser.add_argument(
         "--output-dir",
-        type=pathlib.Path,
+        type=Path,
         default=None,
         help="出力CSVファイルのディレクトリ (デフォルト: data/processed)",
     )

--- a/src/python_etl/extract.py
+++ b/src/python_etl/extract.py
@@ -1,7 +1,7 @@
 """Extract処理 - CSVファイルからデータを読み込む。"""
 
 import logging
-import pathlib
+from pathlib import Path
 from typing import Final
 
 import pandas as pd
@@ -10,12 +10,12 @@ import pandas as pd
 logger: Final[logging.Logger] = logging.getLogger(__name__)
 
 # ディレクトリパスの設定
-BASE_DIR: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parent.parent.parent
-RAW_DIR: Final[pathlib.Path] = BASE_DIR / "data" / "raw"
+BASE_DIR: Final[Path] = Path(__file__).resolve().parent.parent.parent
+RAW_DIR: Final[Path] = BASE_DIR / "data" / "raw"
 
 
 def extract(
-    raw_dir: pathlib.Path | None = None,
+    raw_dir: Path | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """
     CSV ファイルを読み込む。

--- a/src/python_etl/load.py
+++ b/src/python_etl/load.py
@@ -1,7 +1,7 @@
 """Load処理 - 加工結果をCSVファイルに出力する。"""
 
 import logging
-import pathlib
+from pathlib import Path
 from typing import Final
 
 import pandas as pd
@@ -10,8 +10,8 @@ import pandas as pd
 logger: Final[logging.Logger] = logging.getLogger(__name__)
 
 # ディレクトリパスの設定
-BASE_DIR: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parent.parent.parent
-OUT_DIR: Final[pathlib.Path] = BASE_DIR / "data" / "processed"
+BASE_DIR: Final[Path] = Path(__file__).resolve().parent.parent.parent
+OUT_DIR: Final[Path] = BASE_DIR / "data" / "processed"
 
 
 def load(
@@ -20,7 +20,7 @@ def load(
     category_summary: pd.DataFrame,
     daily_sales: pd.DataFrame,
     *,
-    out_dir: pathlib.Path | None = None,
+    out_dir: Path | None = None,
 ) -> None:
     """
     加工結果を CSV に出力する。

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,6 +1,6 @@
 """Tests for ETLパイプライン統合テスト."""
 
-import pathlib
+from pathlib import Path
 from typing import Final
 
 import pandas as pd
@@ -57,7 +57,7 @@ TEST_SALES_DATA: Final[list[dict[str, object]]] = [
 
 
 @pytest.fixture
-def temp_etl_dirs(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+def temp_etl_dirs(tmp_path: Path) -> tuple[Path, Path]:
     """一時的なETL用ディレクトリを作成するfixture。"""
     raw_dir = tmp_path / "raw"
     raw_dir.mkdir()
@@ -71,7 +71,7 @@ def temp_etl_dirs(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
     return raw_dir, out_dir
 
 
-def test_main_integration(temp_etl_dirs: tuple[pathlib.Path, pathlib.Path]) -> None:
+def test_main_integration(temp_etl_dirs: tuple[Path, Path]) -> None:
     """main関数が正常にETLパイプラインを実行することをテスト。"""
     raw_dir, out_dir = temp_etl_dirs
 
@@ -104,11 +104,11 @@ def test_parse_args_with_both_dirs() -> None:
     """--input-dirと--output-dirを両方指定した場合のテスト。"""
     parsed = parse_args(["--input-dir", "/tmp/input", "--output-dir", "/tmp/output"])
 
-    assert parsed.input_dir == pathlib.Path("/tmp/input")
-    assert parsed.output_dir == pathlib.Path("/tmp/output")
+    assert parsed.input_dir == Path("/tmp/input")
+    assert parsed.output_dir == Path("/tmp/output")
 
 
-def test_main_with_nonexistent_input_dir(tmp_path: pathlib.Path) -> None:
+def test_main_with_nonexistent_input_dir(tmp_path: Path) -> None:
     """存在しない入力ディレクトリを指定した場合にOSErrorが発生することをテスト。"""
     non_existent = tmp_path / "does_not_exist"
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,6 +1,6 @@
 """Tests for Extract処理."""
 
-import pathlib
+from pathlib import Path
 from typing import Final
 
 import pandas as pd
@@ -65,7 +65,7 @@ TEST_SALES_DATA: Final[list[dict[str, object]]] = [
 
 
 @pytest.fixture
-def temp_csv_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+def temp_csv_dir(tmp_path: Path) -> Path:
     """一時的なCSVディレクトリを作成するfixture。"""
     raw_dir = tmp_path / "raw"
     raw_dir.mkdir()
@@ -78,7 +78,7 @@ def temp_csv_dir(tmp_path: pathlib.Path) -> pathlib.Path:
     return raw_dir
 
 
-def test_extract_success(temp_csv_dir: pathlib.Path) -> None:
+def test_extract_success(temp_csv_dir: Path) -> None:
     """extract関数が正常にCSVファイルを読み込むことをテスト。"""
     customers, products, sales = extract(raw_dir=temp_csv_dir)
 
@@ -90,7 +90,7 @@ def test_extract_success(temp_csv_dir: pathlib.Path) -> None:
     assert "sale_id" in sales.columns
 
 
-def test_extract_file_not_found(tmp_path: pathlib.Path) -> None:
+def test_extract_file_not_found(tmp_path: Path) -> None:
     """extract関数がファイルが存在しない場合に例外を発生させることをテスト。"""
     non_existent_dir = tmp_path / "non_existent"
 
@@ -98,7 +98,7 @@ def test_extract_file_not_found(tmp_path: pathlib.Path) -> None:
         extract(raw_dir=non_existent_dir)
 
 
-def test_extract_default_dir(temp_csv_dir: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_extract_default_dir(temp_csv_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """引数なしのextract()がデフォルトのRAW_DIRを使用することをテスト。"""
     import importlib
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,6 +1,6 @@
 """Tests for Load処理."""
 
-import pathlib
+from pathlib import Path
 from typing import Final
 
 import pandas as pd
@@ -87,7 +87,7 @@ def test_load(
     sales_df: pd.DataFrame,
     customers_df: pd.DataFrame,
     products_df: pd.DataFrame,
-    tmp_path: pathlib.Path,
+    tmp_path: Path,
 ) -> None:
     """load関数がCSVファイルを正しく出力することをテスト。"""
     # 事前にクレンジングと結合
@@ -116,7 +116,7 @@ def test_load_permission_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def mock_mkdir(*args: object, **kwargs: object) -> None:
         raise PermissionError("Permission denied")
 
-    monkeypatch.setattr(pathlib.Path, "mkdir", mock_mkdir)
+    monkeypatch.setattr(Path, "mkdir", mock_mkdir)
 
     # テストデータを作成
     test_df = pd.DataFrame({"col1": [1, 2, 3]})


### PR DESCRIPTION
## Summary
- 全ファイル (6ファイル) で `import pathlib` → `from pathlib import Path` に変更し、`pathlib.Path` の参照を `Path` に統一
- コードの簡潔性・可読性を向上

Closes #5

## Test plan
- [x] `uv run --frozen ruff format .` — 変更なし
- [x] `uv run --frozen ruff check .` — All checks passed
- [x] `uv run --frozen pyright` — 0 errors
- [x] `uv run --frozen pytest` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)